### PR TITLE
Acoe 7799

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'The repository to checkout if not the repository that triggered the action. For use when building GitHub Apps'
     required: false
 
+  checkout-token:
+    description: 'Token to use for checkout if checking out a repository out of scope for GITHUB_TOKEN'
+    required: false
+
   # java jdk params
 
   java-version:

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'The branch, tag, or SHA of the repository to clone'
     required: false
 
+  checkout-repository:
+    description: 'The repository to checkout if not the repository that triggered the action. For use when building GitHub Apps'
+    required: false
+
   # java jdk params
 
   java-version:
@@ -85,6 +89,7 @@ runs:
         path: '${{ inputs.checkout-path }}'
         persist-credentials: '${{ inputs.checkout-persist-credentials }}'
         ref: '${{ inputs.checkout-ref }}'
+        repository: '${{ inputs.checkout-repository }}'
 
     - uses: actions/setup-java@v3
       with:

--- a/action.yml
+++ b/action.yml
@@ -94,6 +94,7 @@ runs:
         persist-credentials: '${{ inputs.checkout-persist-credentials }}'
         ref: '${{ inputs.checkout-ref }}'
         repository: '${{ inputs.checkout-repository }}'
+        token: '${{ inputs.checkout-token }}'
 
     - uses: actions/setup-java@v3
       with:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which Jira Issues are included. Please also include relevant context. List any dependencies that are required for this change. -->
Added option to checkout repository to resolve challenge with GitHub App that uses workflow_dispatch is checking out the wrong repository.

## Issues:
- [ACOE-7799](https://anixter.atlassian.net/browse/ACOE-7799)

# How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration. -->
- [X] Tested in branch: ACOE-7799 - workflow from testing-runners, also tested multiple workflow dispatches from other repositories - All testing on repositories internal to Wesco

# Checklist
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] I verify that my code meets [WESCO's coding standards and best practices](https://anixter.atlassian.net/wiki/spaces/DSO/pages/2870640838/Policies)

# Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
This is not a breaking change as the input is not required. It should be skipped if empty.


[ACOE-7799]: https://anixter.atlassian.net/browse/ACOE-7799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ